### PR TITLE
Adds windows to CI workflow strategy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ jobs:
         os:
         - ubuntu-latest
         - macos-latest
+        - windows-latest
         toolchain:
         - stable
         - beta
@@ -34,6 +35,9 @@ jobs:
         brew update
         brew install postgresql@16
         brew link postgresql@16
+    - name: Install PostgreSQL on Windows
+      if: matrix.os == 'windows-latest'
+      run: choco install postgresql
     - name: Run unit tests
       run: cargo test --all-features --lib --bins
   integration-test:


### PR DESCRIPTION
Support Windows by giving it a strategy in the CI workflow

# TODO
- [ ] `libpg` cannot be found to build Diesel