### PR TITLE
feat(climb-db): add MIGRATIONS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
   - cron: '00 01 * * *'
 
 jobs:
-  test:
+  unit-test:
     strategy:
       fail-fast: false
       matrix:
@@ -34,6 +34,37 @@ jobs:
         brew update
         brew install postgresql@16
         brew link postgresql@16
-    - name: Run tests
-      run: cargo test --all-features
-
+    - name: Run unit tests
+      run: cargo test --all-features --lib --bins
+  integration-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain:
+        - stable
+        - beta
+        - nightly
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.toolchain }}
+    - name: Run integration tests
+      run: cargo test --test '*'
+      env:
+        TEST_DATABASE_URL: postgres://postgres@localhost

--- a/climb-db/Cargo.toml
+++ b/climb-db/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 diesel = { version = "2.2.2", features = ["postgres"] }
+diesel_migrations = { version = "2.2.0", features = ["postgres"] }

--- a/climb-db/Cargo.toml
+++ b/climb-db/Cargo.toml
@@ -6,3 +6,7 @@ edition = "2021"
 [dependencies]
 diesel = { version = "2.2.2", features = ["postgres"] }
 diesel_migrations = { version = "2.2.0", features = ["postgres"] }
+
+[[test]]
+name = "migrations"
+path = "tests/migrations.rs"

--- a/climb-db/build.rs
+++ b/climb-db/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=migrations");
+}

--- a/climb-db/src/lib.rs
+++ b/climb-db/src/lib.rs
@@ -1,2 +1,5 @@
+use diesel_migrations::{EmbeddedMigrations,embed_migrations};
+
 pub mod models;
 pub mod schema;
+pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");

--- a/climb-db/tests/common/mod.rs
+++ b/climb-db/tests/common/mod.rs
@@ -1,0 +1,49 @@
+use diesel::{Connection, PgConnection, RunQueryDsl};
+use std::env;
+
+pub struct TestDatabase {
+    conn: Option<PgConnection>,
+    db_url: String,
+    db_name: String,
+}
+
+impl TestDatabase {
+    pub fn new(db_name: &str) -> Self {
+        let database_url = env::var("TEST_DATABASE_URL").expect("TEST_DATABASE_URL must be set");
+        let mut conn = PgConnection::establish(&format!("{}/postgres", database_url)).expect("Failed to establish connection with database");
+
+        diesel::sql_query(format!("DROP DATABASE IF EXISTS {}", db_name))
+            .execute(&mut conn)
+            .expect("Failed to drop existing database");
+
+        diesel::sql_query(format!("CREATE DATABASE {}", db_name))
+            .execute(&mut conn)
+            .expect("Failed to make database");
+
+        let conn = PgConnection::establish(&format!("{}/{}", database_url, db_name))
+            .expect("Could not connect to test database");
+
+        TestDatabase {
+            conn: Some(conn),
+            db_url: database_url.to_string(),
+            db_name: db_name.to_string(),
+        }
+    }
+
+    pub fn connection(&mut self) -> &mut PgConnection {
+        self.conn.as_mut().expect("Connection closed")
+    }
+}
+
+impl Drop for TestDatabase {
+    fn drop(&mut self) {
+        // take the connection, effectively dropping it
+        self.conn = None;
+
+        let mut conn = PgConnection::establish(&format!("{}/postgres", self.db_url)).expect("");
+
+        diesel::sql_query(format!("DROP DATABASE {}", self.db_name))
+            .execute(&mut conn)
+            .expect("Failed to drop table");
+    }
+}

--- a/climb-db/tests/migrations.rs
+++ b/climb-db/tests/migrations.rs
@@ -1,0 +1,15 @@
+use common::TestDatabase;
+use diesel_migrations::MigrationHarness;
+
+mod common;
+
+#[test]
+pub fn from_scratch() {
+    // TODO [TestName](https://doc.rust-lang.org/test/enum.TestName.html)
+    let mut db = TestDatabase::new("test__migrations__from_scratch");
+
+    let conn = db.connection();
+    let result = conn.run_pending_migrations(climb_db::MIGRATIONS);
+
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
Add MIGRATIONS constant to allow Rust applications to apply migrations to a database. Includes integration tests in climb-db/tests.