### PR TITLE
refactor(db): remove redundant fk constraints

### DIFF
--- a/climb-db/migrations/2024-08-19-043720_create_climb_belongs_to/up.sql
+++ b/climb-db/migrations/2024-08-19-043720_create_climb_belongs_to/up.sql
@@ -1,10 +1,8 @@
 -- Your SQL goes here
 CREATE TABLE climb_belongs_to (
     climb_id INTEGER PRIMARY KEY REFERENCES climbs(id) ON DELETE CASCADE,
-    area_id INTEGER,
-    formation_id INTEGER,
-    CONSTRAINT fk_areas FOREIGN KEY (area_id) REFERENCES areas(id) ON DELETE RESTRICT,
-    CONSTRAINT fk_formations FOREIGN KEY (formation_id) REFERENCES formations(id) ON DELETE RESTRICT,
+    area_id INTEGER REFERENCES areas(id) ON DELETE RESTRICT,
+    formation_id INTEGER REFERENCES formations(id) ON DELETE RESTRICT,
     CHECK (
         (formation_id IS NOT NULL AND area_id IS NULL) OR
         (formation_id IS NULL AND area_id IS NOT NULL)

--- a/climb-db/migrations/2024-08-26-041136_create_formation_belongs_to/up.sql
+++ b/climb-db/migrations/2024-08-26-041136_create_formation_belongs_to/up.sql
@@ -1,10 +1,8 @@
 -- Your SQL goes here
 CREATE TABLE formation_belongs_to (
     formation_id INTEGER PRIMARY KEY REFERENCES formations(id) ON DELETE CASCADE,
-    area_id INTEGER,
-    super_formation_id INTEGER,
-    CONSTRAINT fk_areas FOREIGN KEY (area_id) REFERENCES areas(id) ON DELETE RESTRICT,
-    CONSTRAINT fk_formations FOREIGN KEY (super_formation_id) REFERENCES formations(id) ON DELETE RESTRICT,
+    area_id INTEGER REFERENCES areas(id) ON DELETE RESTRICT,
+    super_formation_id INTEGER REFERENCES formations(id) ON DELETE RESTRICT,
     CHECK (
         (super_formation_id IS NOT NULL AND area_id IS NULL) OR
         (super_formation_id IS NULL AND area_id IS NOT NULL)

--- a/climb-db/migrations/2024-08-27-033528_create_area_belongs_to/up.sql
+++ b/climb-db/migrations/2024-08-27-033528_create_area_belongs_to/up.sql
@@ -1,8 +1,7 @@
 -- Your SQL goes here
 CREATE TABLE area_belongs_to (
     area_id INTEGER PRIMARY KEY REFERENCES areas(id) ON DELETE CASCADE,
-    super_area_id INTEGER NOT NULL,
-    CONSTRAINT fk_areas FOREIGN KEY (super_area_id) REFERENCES areas(id) ON DELETE RESTRICT
+    super_area_id INTEGER NOT NULL REFERENCES areas(id) ON DELETE RESTRICT
 );
 
 CREATE FUNCTION prevent_area_belongs_to_cycle() RETURNS trigger AS $$


### PR DESCRIPTION
Removes redundant foreign key constraints. Single-column "REFERENCES" do the same job as explicit FOREIGN KEY constraints in these scenarios and provide better readability.