### PR TITLE
refactor: add app-data structure for global context

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,10 @@ struct Config {
     pub graphqlport: u32,
 }
 
+pub struct AppData {
+    pub pg_pool: deadpool_postgres::Pool,
+}
+
 impl Config {
     pub fn from_env() -> Result<Self, config::ConfigError> {
         let cfg = config::Config::builder()
@@ -39,9 +43,10 @@ impl Config {
 #[tokio::main]
 async fn main() {
     let cfg = Config::from_env().expect("Environment was not enough to setup configuration");
-    let pool = cfg.pg.create_pool(Some(Runtime::Tokio1), NoTls).expect("Could not create pool");
+    let pg_pool = cfg.pg.create_pool(Some(Runtime::Tokio1), NoTls).expect("Could not create pool");
+    let context = AppData { pg_pool };
     let schema = Schema::build(QueryRoot, MutationRoot, EmptySubscription)
-        .data(pool)
+        .data(context)
         .finish();
 
     let app = Router::new().route("/graphql", get(graphiql).post_service(GraphQL::new(schema)));

--- a/src/schema/area.rs
+++ b/src/schema/area.rs
@@ -1,8 +1,8 @@
 use async_graphql::{Context, Object, Result};
-use deadpool_postgres::Pool;
 
 use crate::schema::climb::Climb;
 use crate::schema::formation::Formation;
+use crate::AppData;
 
 pub struct Area(pub i32);
 
@@ -13,8 +13,8 @@ impl Area {
     }
 
     async fn name<'a>(&self, ctx: &Context<'a>) -> Result<Option<String>> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         let result = client
             .query_one("SELECT name FROM areas WHERE id = $1", &[&self.0])
@@ -25,8 +25,8 @@ impl Area {
     }
 
     async fn area<'a>(&self, ctx: &Context<'a>) -> Result<Option<Area>> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         let result = client
             .query(
@@ -44,8 +44,8 @@ impl Area {
     }
 
     async fn areas<'a>(&self, ctx: &Context<'a>) -> Result<Vec<Area>> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         let result = client
             .query(
@@ -62,8 +62,8 @@ impl Area {
     }
 
     async fn formations<'a>(&self, ctx: &Context<'a>) -> Result<Vec<Formation>> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         let result = client
             .query(
@@ -80,8 +80,8 @@ impl Area {
     }
 
     async fn climbs<'a>(&self, ctx: &Context<'a>) -> Result<Vec<Climb>> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         let result = client
             .query(

--- a/src/schema/climb.rs
+++ b/src/schema/climb.rs
@@ -1,9 +1,9 @@
 use async_graphql::{Context, Enum, Object, Result, SimpleObject, Union};
-use deadpool_postgres::Pool;
 use postgres_types::FromSql;
 
 use crate::schema::area::Area;
 use crate::schema::formation::Formation;
+use crate::AppData;
 
 #[derive(Union)]
 enum ClimbParent {
@@ -69,8 +69,8 @@ impl Climb {
     }
 
     async fn name<'a>(&self, ctx: &Context<'a>) -> Result<Option<String>> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         let result = client
             .query_one("SELECT name FROM climbs WHERE id = $1", &[&self.0])
@@ -81,8 +81,8 @@ impl Climb {
     }
 
     async fn grades<'a>(&self, ctx: &Context<'a>) -> Result<Vec<Grade>> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         let verm_grades: Vec<Grade> = client
             .query(
@@ -168,8 +168,8 @@ impl Climb {
     }
 
     async fn parent<'a>(&self, ctx: &Context<'a>) -> Result<Option<ClimbParent>> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         let result = client
             .query_opt(

--- a/src/schema/formation.rs
+++ b/src/schema/formation.rs
@@ -1,8 +1,8 @@
 use async_graphql::{Context, InputObject, Object, Result, SimpleObject, Union};
-use deadpool_postgres::Pool;
 
 use crate::schema::area::Area;
 use crate::schema::climb::Climb;
+use crate::AppData;
 
 #[derive(SimpleObject, InputObject)]
 #[graphql(input_name = "CoordinateInput")]
@@ -26,8 +26,8 @@ impl Formation {
     }
 
     async fn name<'a>(&self, ctx: &Context<'a>) -> Result<Option<String>> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         let result = client
             .query_one("SELECT name FROM formations WHERE id = $1", &[&self.0])
@@ -38,8 +38,8 @@ impl Formation {
     }
 
     async fn location<'a>(&self, ctx: &Context<'a>) -> Result<Option<Coordinate>> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         let maybe_point = client
             .query_one("SELECT location FROM formations WHERE id = $1", &[&self.0])
@@ -53,8 +53,8 @@ impl Formation {
     }
 
     async fn parent<'a>(&self, ctx: &Context<'a>) -> Result<Option<FormationParent>> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         let result = client
             .query_opt(
@@ -90,8 +90,8 @@ impl Formation {
     }
 
     async fn formations<'a>(&self, ctx: &Context<'a>) -> Result<Vec<Formation>> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         let result = client.query("SELECT formation_id FROM formation_super_formation_closures WHERE super_formation_id = $1", &[&self.0]).await?;
         let formations = result
@@ -103,8 +103,8 @@ impl Formation {
     }
 
     async fn climbs<'a>(&self, ctx: &Context<'a>) -> Result<Vec<Climb>> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         let result = client
             .query(

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -1,10 +1,11 @@
 use async_graphql::{Context, Enum, InputObject, Object, OneofObject, Result};
-use deadpool_postgres::Pool;
 
 use area::Area;
 use climb::Climb;
 use formation::{Coordinate, Formation};
 use postgres_types::ToSql;
+
+use crate::AppData;
 
 pub mod area;
 pub mod climb;
@@ -74,8 +75,8 @@ impl QueryRoot {
         ctx: &Context<'a>,
         #[graphql(desc = "Parent area id")] area_id: Option<i32>,
     ) -> Result<Vec<Area>> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         let result = if let Some(area_id) = area_id {
             // If `area_id` is provided, find areas with this specific parent
@@ -118,8 +119,8 @@ impl QueryRoot {
         ctx: &Context<'a>,
         #[graphql(desc = "Area id")] id: i32,
     ) -> Result<Area> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         // Just check for existence
         client
@@ -135,8 +136,8 @@ impl QueryRoot {
         #[graphql(desc = "Parent area id")] area_id: Option<i32>,
         #[graphql(desc = "Parent formation id")] formation_id: Option<i32>,
     ) -> Result<Vec<Climb>> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         let result = if let Some(area_id) = area_id {
             // If `area_id` is provided, find climbs with this specific parent
@@ -193,8 +194,8 @@ impl QueryRoot {
         ctx: &Context<'a>,
         #[graphql(desc = "Climb id")] id: i32,
     ) -> Result<Climb> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         // Just check for existence
         client
@@ -210,8 +211,8 @@ impl QueryRoot {
         #[graphql(desc = "Parent area id")] area_id: Option<i32>,
         #[graphql(desc = "Parent formation id")] formation_id: Option<i32>,
     ) -> Result<Vec<Formation>> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         let result = if let Some(area_id) = area_id {
             // If `area_id` is provided, find formations with this specific parent
@@ -268,8 +269,8 @@ impl QueryRoot {
         ctx: &Context<'a>,
         #[graphql(desc = "Formation id")] id: i32,
     ) -> Result<Formation> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         // Just check for existence
         client
@@ -302,8 +303,8 @@ impl MutationRoot {
         #[graphql(desc = "Area name")] name: Option<String>,
         #[graphql(desc = "Super area id")] super_area_id: Option<i32>,
     ) -> Result<Area> {
-        let pool = ctx.data::<Pool>()?;
-        let mut client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let mut client = data.pg_pool.get().await?;
 
         let transaction = client.transaction().await?;
 
@@ -335,8 +336,8 @@ impl MutationRoot {
         #[graphql(desc = "Area id")] id: i32,
         #[graphql(desc = "Area name")] name: Option<String>,
     ) -> Result<Area> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         let area_id = client
             .query_one(
@@ -355,8 +356,8 @@ impl MutationRoot {
         #[graphql(desc = "Area id")] id: i32,
         #[graphql(desc = "Super area id")] super_area_id: Option<i32>,
     ) -> Result<Area> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         if let Some(super_area_id) = super_area_id {
             client
@@ -385,8 +386,8 @@ impl MutationRoot {
         ctx: &Context<'a>,
         #[graphql(desc = "Area id")] id: i32,
     ) -> Result<Area> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         client
             .execute("DELETE FROM areas WHERE id = $1", &[&id])
@@ -401,8 +402,8 @@ impl MutationRoot {
         #[graphql(desc = "Climb name")] name: Option<String>,
         #[graphql(desc = "Climb parent")] parent: Option<ClimbParentInput>,
     ) -> Result<Climb> {
-        let pool = ctx.data::<Pool>()?;
-        let mut client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let mut client = data.pg_pool.get().await?;
 
         let transaction = client.transaction().await?;
 
@@ -447,8 +448,8 @@ impl MutationRoot {
         #[graphql(desc = "Climb id")] id: i32,
         #[graphql(desc = "Climb name")] name: Option<String>,
     ) -> Result<Climb> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         let id = client
             .query_one(
@@ -467,8 +468,8 @@ impl MutationRoot {
         #[graphql(desc = "Climb id")] id: i32,
         #[graphql(desc = "Climb parent")] parent: Option<ClimbParentInput>,
     ) -> Result<Climb> {
-        let pool = ctx.data::<Pool>()?;
-        let mut client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let mut client = data.pg_pool.get().await?;
 
         let transaction = client.transaction().await?;
 
@@ -532,8 +533,8 @@ impl MutationRoot {
         #[graphql(desc = "Grade")] grade: GradeInput,
         #[graphql(desc = "Operation")] operation: GradeOperation,
     ) -> Result<Climb> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         match operation {
             GradeOperation::Add => match grade {
@@ -623,8 +624,8 @@ impl MutationRoot {
         ctx: &Context<'a>,
         #[graphql(desc = "Climb id")] id: i32,
     ) -> Result<Climb> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         client
             .execute("DELETE FROM climbs WHERE id = $1", &[&id])
@@ -641,8 +642,8 @@ impl MutationRoot {
         #[graphql(desc = "Formation location")] location: Option<Coordinate>,
         #[graphql(desc = "Formation parent")] parent: Option<FormationParentInput>,
     ) -> Result<Formation> {
-        let pool = ctx.data::<Pool>()?;
-        let mut client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let mut client = data.pg_pool.get().await?;
 
         let transaction = client.transaction().await?;
 
@@ -690,8 +691,8 @@ impl MutationRoot {
         #[graphql(desc = "Formation id")] id: i32,
         #[graphql(desc = "Formation name")] name: Option<String>,
     ) -> Result<Formation> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         let id = client
             .query_one(
@@ -710,8 +711,8 @@ impl MutationRoot {
         #[graphql(desc = "Formation id")] id: i32,
         #[graphql(desc = "Formation location")] location: Option<Coordinate>,
     ) -> Result<Formation> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         let point =
             location.map(|coord| postgis::ewkb::Point::new(coord.longitude, coord.latitude, None));
@@ -733,8 +734,8 @@ impl MutationRoot {
         #[graphql(desc = "Formation id")] id: i32,
         #[graphql(desc = "Formation parent")] parent: Option<FormationParentInput>,
     ) -> Result<Formation> {
-        let pool = ctx.data::<Pool>()?;
-        let mut client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let mut client = data.pg_pool.get().await?;
 
         let transaction = client.transaction().await?;
 
@@ -795,8 +796,8 @@ impl MutationRoot {
         ctx: &Context<'a>,
         #[graphql(desc = "Formation id")] id: i32,
     ) -> Result<Formation> {
-        let pool = ctx.data::<Pool>()?;
-        let client = pool.get().await?;
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
 
         client
             .execute("DELETE FROM formations WHERE id = $1", &[&id])


### PR DESCRIPTION
When we add multiple services to help facilitate queries, mutations, etc.. we will need to pull from other data as well.. by encapsulating the context now this will allow extending with those other services.