### PR TITLE
Allow for all entity queries

### DIFF
--- a/src/schema/area.rs
+++ b/src/schema/area.rs
@@ -1,8 +1,13 @@
-use async_graphql::{Context, Object, Result};
+use async_graphql::{Context, Object, Result, Union};
 
 use crate::schema::climb::Climb;
 use crate::schema::formation::Formation;
 use crate::AppData;
+
+#[derive(Union)]
+enum AreaParent {
+    Area(Area),
+}
 
 pub struct Area(pub i32);
 
@@ -24,7 +29,7 @@ impl Area {
         Ok(value.map(|name| name.to_string()))
     }
 
-    async fn area<'a>(&self, ctx: &Context<'a>) -> Result<Option<Area>> {
+    async fn parent<'a>(&self, ctx: &Context<'a>) -> Result<Option<AreaParent>> {
         let data = ctx.data::<AppData>()?;
         let client = data.pg_pool.get().await?;
 
@@ -40,7 +45,7 @@ impl Area {
             None
         };
 
-        Ok(value.map(Area))
+        Ok(value.map(Area).map(AreaParent::Area))
     }
 
     async fn areas<'a>(&self, ctx: &Context<'a>) -> Result<Vec<Area>> {

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -281,53 +281,13 @@ impl QueryRoot {
     async fn formations<'a>(
         &self,
         ctx: &Context<'a>,
-        #[graphql(desc = "Parent area id")] area_id: Option<i32>,
-        #[graphql(desc = "Parent formation id")] formation_id: Option<i32>,
     ) -> Result<Vec<Formation>> {
         let data = ctx.data::<AppData>()?;
         let client = data.pg_pool.get().await?;
 
-        let result = if let Some(area_id) = area_id {
-            // If `area_id` is provided, find formations with this specific parent
-            client
-                .query(
-                    "
-                    SELECT f.id
-                    FROM formations AS f
-                    INNER JOIN formation_super_area_closures AS sa ON f.id = sa.formation_id
-                    WHERE sa.super_area_id = $1
-                    ",
-                    &[&area_id],
-                )
-                .await?
-        } else if let Some(formation_id) = formation_id {
-            // If `formation_id` is provided, find formations with this specific parent
-            client
-                .query(
-                    "
-                    SELECT f.id
-                    FROM formations AS f
-                    INNER JOIN formation_super_formation_closures AS sf ON f.id = sf.formation_id
-                    WHERE sf.super_formation_id = $1
-                    ",
-                    &[&formation_id],
-                )
-                .await?
-        } else {
-            // If `area_id` and `formation_id` are None, find formations with no parent (top-level formations)
-            client
-                .query(
-                    "
-                    SELECT f.id
-                    FROM formations AS f
-                    LEFT JOIN formation_super_area_closures AS sa ON f.id = sa.formation_id
-                    LEFT JOIN formation_super_formation_closures AS sf ON f.id = sf.formation_id
-                    WHERE sa.super_area_id IS NULL AND sf.super_formation_id IS NULL
-                    ",
-                    &[],
-                )
-                .await?
-        };
+        let result = client
+            .query("SELECT formations.id FROM formations", &[])
+            .await?;
 
         let formations = result
             .into_iter()

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -187,53 +187,13 @@ impl QueryRoot {
     async fn climbs<'a>(
         &self,
         ctx: &Context<'a>,
-        #[graphql(desc = "Parent area id")] area_id: Option<i32>,
-        #[graphql(desc = "Parent formation id")] formation_id: Option<i32>,
     ) -> Result<Vec<Climb>> {
         let data = ctx.data::<AppData>()?;
         let client = data.pg_pool.get().await?;
 
-        let result = if let Some(area_id) = area_id {
-            // If `area_id` is provided, find climbs with this specific parent
-            client
-                .query(
-                    "
-                    SELECT c.id
-                    FROM climbs AS c
-                    INNER JOIN climb_super_area_closures AS sa ON c.id = sa.climb_id
-                    WHERE sa.super_area_id = $1
-                    ",
-                    &[&area_id],
-                )
-                .await?
-        } else if let Some(formation_id) = formation_id {
-            // If `formation_id` is provided, find climbs with this specific parent
-            client
-                .query(
-                    "
-                    SELECT c.id
-                    FROM climbs AS c
-                    INNER JOIN climb_super_formation_closures AS sf ON c.id = sf.climb_id
-                    WHERE sf.super_formation_id = $1
-                    ",
-                    &[&formation_id],
-                )
-                .await?
-        } else {
-            // If `area_id` and `formation_id` are None, find climbs with no parent (top-level climbs)
-            client
-                .query(
-                    "
-                    SELECT c.id
-                    FROM climbs AS c
-                    LEFT JOIN climb_super_area_closures AS sa ON c.id = sa.climb_id
-                    LEFT JOIN climb_super_formation_closures AS sf ON c.id = sf.climb_id
-                    WHERE sa.super_area_id IS NULL AND sf.super_formation_id IS NULL
-                    ",
-                    &[],
-                )
-                .await?
-        };
+        let result = client
+            .query("SELECT climbs.id FROM climbs", &[])
+            .await?;
 
         let climbs = result
             .into_iter()

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -168,6 +168,51 @@ impl QueryRoot {
         Ok(areas)
     }
 
+    async fn areas_by_parent<'a>(
+        &self,
+        ctx: &Context<'a>,
+        #[graphql(desc = "Area parent")] parent: Option<AreaParentInput>,
+    ) -> Result<Vec<Area>> {
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
+
+        let result = match parent {
+            Some(AreaParentInput::Area(area_id)) => {
+                client
+                    .query(
+                        "
+                        SELECT a.id
+                        FROM areas AS a
+                        INNER JOIN area_closures AS sa ON a.id = sa.area_id
+                        WHERE sa.super_area_id = $1
+                        ",
+                        &[&area_id],
+                    )
+                    .await?
+            }
+            None => {
+                client
+                    .query(
+                        "
+                        SELECT a.id
+                        FROM areas AS a
+                        LEFT JOIN area_closures AS sa ON a.id = sa.area_id
+                        WHERE sa.super_area_id IS NULL
+                        ",
+                        &[],
+                    )
+                    .await?
+            }
+        };
+
+        let areas = result
+            .into_iter()
+            .map(|row| row.try_get(0).map(Area))
+            .collect::<Result<Vec<Area>, _>>()?;
+
+        Ok(areas)
+    }
+
     async fn area<'a>(
         &self,
         ctx: &Context<'a>,

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -337,6 +337,65 @@ impl QueryRoot {
         Ok(formations)
     }
 
+    async fn formations_by_parent<'a>(
+        &self,
+        ctx: &Context<'a>,
+        #[graphql(desc = "Formation parent")] parent: Option<FormationParentInput>,
+    ) -> Result<Vec<Formation>> {
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
+
+        let result = match parent {
+            Some(FormationParentInput::Area(area_id)) => {
+                client
+                    .query(
+                        "
+                        SELECT c.id
+                        FROM formations AS c
+                        INNER JOIN formation_super_area_closures AS sa ON c.id = sa.formation_id
+                        WHERE sa.super_area_id = $1
+                        ",
+                        &[&area_id],
+                    )
+                    .await?
+            }
+            Some(FormationParentInput::Formation(formation_id)) => {
+                client
+                    .query(
+                        "
+                        SELECT c.id
+                        FROM formations AS c
+                        INNER JOIN formation_super_formation_closures AS sf ON c.id = sf.formation_id
+                        WHERE sf.super_formation_id = $1
+                        ",
+                        &[&formation_id],
+                    )
+                    .await?
+            }
+            None => {
+                client
+                    .query(
+                        "
+                        SELECT c.id
+                        FROM formations AS c
+                        LEFT JOIN formation_super_area_closures AS sa ON c.id = sa.formation_id
+                        LEFT JOIN formation_super_formation_closures AS sf ON c.id = sf.formation_id
+                        WHERE sa.super_area_id IS NULL AND sf.super_formation_id IS NULL
+                        ",
+                        &[],
+                    )
+                    .await?
+            }
+        };
+
+        let formations = result
+            .into_iter()
+            .map(|row| row.try_get(0).map(Formation))
+            .collect::<Result<Vec<Formation>, _>>()?;
+
+        Ok(formations)
+    }
+
     async fn formation<'a>(
         &self,
         ctx: &Context<'a>,

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -127,38 +127,13 @@ impl QueryRoot {
     async fn areas<'a>(
         &self,
         ctx: &Context<'a>,
-        #[graphql(desc = "Parent area id")] area_id: Option<i32>,
     ) -> Result<Vec<Area>> {
         let data = ctx.data::<AppData>()?;
         let client = data.pg_pool.get().await?;
 
-        let result = if let Some(area_id) = area_id {
-            // If `area_id` is provided, find areas with this specific parent
-            client
-                .query(
-                    "
-                    SELECT a.id
-                    FROM areas AS a
-                    INNER JOIN area_closures AS sa ON a.id = sa.area_id
-                    WHERE sa.super_area_id = $1
-                    ",
-                    &[&area_id],
-                )
-                .await?
-        } else {
-            // If `area_id` is None, find areas with no parent (top-level areas)
-            client
-                .query(
-                    "
-                    SELECT a.id
-                    FROM areas AS a
-                    LEFT JOIN area_closures AS sa ON a.id = sa.area_id
-                    WHERE sa.super_area_id IS NULL
-                    ",
-                    &[],
-                )
-                .await?
-        };
+        let result = client
+            .query("SELECT areas.id FROM areas", &[])
+            .await?;
 
         let areas = result
             .into_iter()

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -243,6 +243,65 @@ impl QueryRoot {
         Ok(climbs)
     }
 
+    async fn climbs_by_parent<'a>(
+        &self,
+        ctx: &Context<'a>,
+        #[graphql(desc = "Climb parent")] parent: Option<ClimbParentInput>,
+    ) -> Result<Vec<Climb>> {
+        let data = ctx.data::<AppData>()?;
+        let client = data.pg_pool.get().await?;
+
+        let result = match parent {
+            Some(ClimbParentInput::Area(area_id)) => {
+                client
+                    .query(
+                        "
+                        SELECT c.id
+                        FROM climbs AS c
+                        INNER JOIN climb_super_area_closures AS sa ON c.id = sa.climb_id
+                        WHERE sa.super_area_id = $1
+                        ",
+                        &[&area_id],
+                    )
+                    .await?
+            }
+            Some(ClimbParentInput::Formation(formation_id)) => {
+                client
+                    .query(
+                        "
+                        SELECT c.id
+                        FROM climbs AS c
+                        INNER JOIN climb_super_formation_closures AS sf ON c.id = sf.climb_id
+                        WHERE sf.super_formation_id = $1
+                        ",
+                        &[&formation_id],
+                    )
+                    .await?
+            }
+            None => {
+                client
+                    .query(
+                        "
+                        SELECT c.id
+                        FROM climbs AS c
+                        LEFT JOIN climb_super_area_closures AS sa ON c.id = sa.climb_id
+                        LEFT JOIN climb_super_formation_closures AS sf ON c.id = sf.climb_id
+                        WHERE sa.super_area_id IS NULL AND sf.super_formation_id IS NULL
+                        ",
+                        &[],
+                    )
+                    .await?
+            }
+        };
+
+        let climbs = result
+            .into_iter()
+            .map(|row| row.try_get(0).map(Climb))
+            .collect::<Result<Vec<Climb>, _>>()?;
+
+        Ok(climbs)
+    }
+
     async fn climb<'a>(
         &self,
         ctx: &Context<'a>,

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -430,6 +430,11 @@ impl QueryRoot {
 }
 
 #[derive(OneofObject)]
+enum AreaParentInput {
+    Area(i32),
+}
+
+#[derive(OneofObject)]
 enum ClimbParentInput {
     Area(i32),
     Formation(i32),
@@ -502,28 +507,28 @@ impl MutationRoot {
         &self,
         ctx: &Context<'a>,
         #[graphql(desc = "Area id")] id: i32,
-        #[graphql(desc = "Super area id")] super_area_id: Option<i32>,
+        #[graphql(desc = "Area parent")] parent: Option<AreaParentInput>,
     ) -> Result<Area> {
         let data = ctx.data::<AppData>()?;
         let client = data.pg_pool.get().await?;
 
-        if let Some(super_area_id) = super_area_id {
-            client
-                .execute(
-                    "
-                    INSERT INTO area_closures (area_id, super_area_id)
-                    VALUES ($1, $2)
-                    ON CONFLICT (area_id)
-                    DO UPDATE SET
-                    super_area_id = EXCLUDED.super_area_id
-                    ",
-                    &[&id, &super_area_id],
-                )
-                .await?;
-        } else {
-            client
-                .execute("DELETE FROM area_closures WHERE area_id = $1", &[&id])
-                .await?;
+        if let Some(parent) = parent {
+            match parent {
+                AreaParentInput::Area(area_id) => {
+                    client
+                        .execute(
+                            "
+                            INSERT INTO area_closures (area_id, super_area_id)
+                            VALUES ($1, $2)
+                            ON CONFLICT (area_id)
+                            DO UPDATE SET
+                            super_area_id = EXCLUDED.super_area_id
+                            ",
+                            &[&id, &area_id],
+                        )
+                        .await?;
+                }
+            }
         }
 
         Ok(Area(id))


### PR DESCRIPTION
During my last refactor, I crippled myself when it comes to large queries and removed the ability to get all of a particular entity. These patches refactor those general entity queries so I can query all entities, entities with a particular parent, or entities with explicitly no parent.