### PR TITLE
feat: add ascents type and simple getters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ async-graphql = "7.0.7"
 async-graphql-axum = "7.0.7"
 axum = "0.7.5"
 bytes = "1.10.1"
+chrono = "0.4.40"
 config = "0.14.1"
 deadpool = "0.12.1"
 deadpool-postgres = { version = "0.14.0", features = ["serde"] }

--- a/src/schema/climb.rs
+++ b/src/schema/climb.rs
@@ -1,69 +1,15 @@
-use std::str::FromStr;
-
-use async_graphql::{Context, Object, Result, SimpleObject, Union, ID};
+use async_graphql::{Context, Object, Result, Union, ID};
 
 use crate::schema::area::Area;
 use crate::schema::formation::Formation;
-use crate::schema::fontainebleau_grade::FontainebleauGrade;
-use crate::schema::vermin_grade::VerminGrade;
-use crate::schema::yosemite_decimal_grade::YosemiteDecimalGrade;
 use crate::AppData;
+
+use super::grade::Grade;
 
 #[derive(Union)]
 enum ClimbParent {
     Area(Area),
     Formation(Formation),
-}
-
-#[derive(SimpleObject)]
-struct ClimbFontainebleauGrade {
-    pub value: FontainebleauGrade,
-}
-
-#[derive(SimpleObject)]
-struct ClimbYosemiteDecimalGrade {
-    pub value: YosemiteDecimalGrade,
-}
-
-#[derive(SimpleObject)]
-struct ClimbVerminGrade {
-    pub value: VerminGrade,
-}
-
-#[derive(Union)]
-enum ClimbGrade {
-    Vermin(ClimbVerminGrade),
-    Fontainebleau(ClimbFontainebleauGrade),
-    YosemiteDecimal(ClimbYosemiteDecimalGrade),
-}
-
-#[derive(Debug, PartialEq, Eq)]
-struct ParseClimbGradeError;
-
-impl FromStr for ClimbGrade {
-    type Err = ParseClimbGradeError;
-
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        VerminGrade::from_str(s)
-            .map(|v| {
-                ClimbGrade::Vermin(ClimbVerminGrade { value: v })
-            })
-        .or_else(|_| {
-            FontainebleauGrade::from_str(s)
-                .map(|f| {
-                    ClimbGrade::Fontainebleau(ClimbFontainebleauGrade { value: f })
-                })
-        })
-        .or_else(|_| {
-            YosemiteDecimalGrade::from_str(s)
-                .map(|y| {
-                    ClimbGrade::YosemiteDecimal(ClimbYosemiteDecimalGrade { value: y })
-                })
-        })
-        .map_err(|_| {
-            ParseClimbGradeError
-        })
-    }
 }
 
 pub struct Climb(pub i32);
@@ -108,7 +54,7 @@ impl Climb {
         Ok(value.map(|description| description.to_string()))
     }
 
-    async fn grades<'a>(&self, ctx: &Context<'a>) -> Result<Vec<ClimbGrade>> {
+    async fn grades<'a>(&self, ctx: &Context<'a>) -> Result<Vec<Grade>> {
         let data = ctx.data::<AppData>()?;
         let client = match &data.pg_pool {
             Some(pool) => pool.get().await?,
@@ -117,7 +63,7 @@ impl Climb {
             }
         };
 
-        let value: Vec<ClimbGrade> = client
+        let value: Vec<Grade> = client
             // TODO since grade doesn't implement binary functions, we must request the text
             // format, when grade _does_ implement these, the ::TEXT is not needed
             .query(
@@ -132,7 +78,7 @@ impl Climb {
             .into_iter()
             .filter_map(|row| {
                 let grade_str: String = row.get(0);
-                match grade_str.parse::<ClimbGrade>() {
+                match grade_str.parse::<Grade>() {
                     Ok(grade) => Some(grade),
                     Err(_) => None,
                 }

--- a/src/schema/date_interval.rs
+++ b/src/schema/date_interval.rs
@@ -1,0 +1,153 @@
+use std::{fmt::Display, ops::Bound, str::FromStr};
+
+use async_graphql::{InputValueError, InputValueResult, Scalar, ScalarType, Value};
+use chrono::{Duration, NaiveDate};
+
+#[derive(Debug, PartialEq)]
+pub struct DateInterval(pub Bound<NaiveDate>, pub Bound<NaiveDate>);
+
+impl Display for DateInterval {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // TODO This implementation is naive, I can think of several simplifications off the top of
+        // my head such as..
+        // - [2024-03-01, 2024-03-02) --> 2024-03-02
+        // - [2024-03-01, 2024-04-01) --> 2024-03
+        // - [2024-01-01, 2025-01-01) --> 2024
+
+        let start = match &self.0 {
+            Bound::Included(date) => date.to_string(),
+            Bound::Excluded(date) => (*date + Duration::days(1)).to_string(),
+            Bound::Unbounded => String::from(".."),
+        };
+
+        let end = match &self.1 {
+            Bound::Included(date) => date.to_string(),
+            Bound::Excluded(date) => (*date - Duration::days(1)).to_string(),
+            Bound::Unbounded => String::from(".."),
+        };
+
+        write!(f, "{}/{}", start, end)
+    }
+}
+
+#[derive(Debug)]
+pub struct ParseDateIntervalError;
+
+impl FromStr for DateInterval {
+    type Err = ParseDateIntervalError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split('/').collect();
+        if parts.len() != 2 {
+            return Err(ParseDateIntervalError);
+        }
+
+        let parse_bound = |s: &str| -> Result<Bound<NaiveDate>, ParseDateIntervalError> {
+            if s == ".." {
+                Ok(Bound::Unbounded)
+            } else {
+                NaiveDate::from_str(s)
+                    .map(Bound::Included)
+                    .map_err(|_| ParseDateIntervalError)
+            }
+        };
+
+        let start = parse_bound(parts[0])?;
+        let end = parse_bound(parts[1])?;
+
+        Ok(DateInterval(start, end))
+    }
+}
+
+#[Scalar]
+impl ScalarType for DateInterval {
+    fn parse(value: Value) -> InputValueResult<Self> {
+        if let Value::String(s) = &value {
+            s.parse::<Self>().map_err(|_| InputValueError::custom("Invalid format"))
+        } else {
+            Err(InputValueError::custom("Expected a string"))
+        }
+    }
+
+    fn to_value(&self) -> Value {
+        Value::String(self.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fmt() {
+        assert_eq!(
+            format!("{}", DateInterval(Bound::Unbounded, Bound::Unbounded)),
+            "../.."
+        );
+
+        assert_eq!(
+            format!(
+                "{}",
+                DateInterval(
+                    Bound::Included(NaiveDate::from_ymd_opt(2024, 3, 1).unwrap()),
+                    Bound::Unbounded
+                )
+            ),
+            "2024-03-01/.."
+        );
+
+        assert_eq!(
+            format!(
+                "{}",
+                DateInterval(
+                    Bound::Unbounded,
+                    Bound::Included(NaiveDate::from_ymd_opt(2024, 3, 31).unwrap())
+                )
+            ),
+            "../2024-03-31"
+        );
+
+        assert_eq!(
+            format!(
+                "{}",
+                DateInterval(
+                    Bound::Included(NaiveDate::from_ymd_opt(2024, 3, 1).unwrap()),
+                    Bound::Included(NaiveDate::from_ymd_opt(2024, 3, 31).unwrap())
+                )
+            ),
+            "2024-03-01/2024-03-31"
+        );
+    }
+
+    #[test]
+    fn from_str() {
+        assert_eq!(
+            DateInterval(Bound::Unbounded, Bound::Unbounded),
+            "../..".to_string().parse::<DateInterval>().expect("Is valid")
+        );
+
+        assert_eq!(
+            DateInterval(
+                Bound::Included(NaiveDate::from_ymd_opt(2024, 3, 1).unwrap()),
+                Bound::Unbounded
+            ),
+            "2024-03-01/..".to_string().parse::<DateInterval>().expect("Is valid")
+        );
+
+        assert_eq!(
+            DateInterval(
+                Bound::Unbounded,
+                Bound::Included(NaiveDate::from_ymd_opt(2024, 3, 31).unwrap())
+            ),
+            "../2024-03-31".to_string().parse::<DateInterval>().expect("Is valid")
+        );
+
+        assert_eq!(
+            DateInterval(
+                Bound::Included(NaiveDate::from_ymd_opt(2024, 3, 1).unwrap()),
+                Bound::Included(NaiveDate::from_ymd_opt(2024, 3, 31).unwrap())
+            ),
+            "2024-03-01/2024-03-31".to_string().parse::<DateInterval>().expect("Is valid")
+        );
+    }
+}

--- a/src/schema/date_interval.rs
+++ b/src/schema/date_interval.rs
@@ -1,7 +1,8 @@
-use std::{fmt::Display, ops::Bound, str::FromStr};
+use std::{error::Error, fmt::Display, ops::Bound, str::FromStr};
 
 use async_graphql::{InputValueError, InputValueResult, Scalar, ScalarType, Value};
 use chrono::{Duration, NaiveDate};
+use postgres_types::{accepts, FromSql};
 
 #[derive(Debug, PartialEq)]
 pub struct DateInterval(pub Bound<NaiveDate>, pub Bound<NaiveDate>);
@@ -33,6 +34,15 @@ impl Display for DateInterval {
 #[derive(Debug)]
 pub struct ParseDateIntervalError;
 
+impl Display for ParseDateIntervalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Failed to parse PostgreSQL DATERANGE")
+    }
+}
+
+impl Error for ParseDateIntervalError { }
+
+
 impl FromStr for DateInterval {
     type Err = ParseDateIntervalError;
 
@@ -56,6 +66,66 @@ impl FromStr for DateInterval {
         let end = parse_bound(parts[1])?;
 
         Ok(DateInterval(start, end))
+    }
+}
+
+impl<'a> FromSql<'a> for DateInterval {
+    fn from_sql(ty: &postgres_types::Type, raw: &'a [u8]) -> std::result::Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+        match *ty {
+            postgres_types::Type::DATE_RANGE => todo!(),
+            postgres_types::Type::TEXT => {
+                let text = std::str::from_utf8(raw)?;
+                let parsed = DateInterval::from_pg_range_text(text)?;
+                Ok(parsed)
+            },
+            _ => Err(format!("Unsupported type: {:?}", ty).into()),
+        }
+    }
+
+    accepts!(DATE_RANGE, TEXT);
+}
+
+impl DateInterval {
+    fn from_pg_range_text(s: &str) -> std::result::Result<Self, ParseDateIntervalError> {
+        let trimmed = s.trim();
+
+        if trimmed.len() < 3 || (!trimmed.starts_with(['[', '('])) || (!trimmed.ends_with([']', ')'])) {
+            return Err(ParseDateIntervalError);
+        }
+
+        let start_closed = trimmed.starts_with('[');
+        let end_closed = trimmed.ends_with(']');
+
+        let inner = &trimmed[1..trimmed.len() - 1];
+        let parts: Vec<&str> = inner.split(',').map(|s| s.trim()).collect();
+
+        let start_bound = match parts.first() {
+            Some(date_str) if !date_str.is_empty() => {
+                let date = NaiveDate::parse_from_str(date_str, "%Y-%m-%d")
+                    .map_err(|_| ParseDateIntervalError)?;
+                if start_closed {
+                    Bound::Included(date)
+                } else {
+                    Bound::Excluded(date)
+                }
+            }
+            _ => Bound::Unbounded,
+        };
+
+        let end_bound = match parts.get(1).copied() {
+            Some(date_str) if !date_str.is_empty() => {
+                let date = NaiveDate::parse_from_str(date_str, "%Y-%m-%d")
+                    .map_err(|_| ParseDateIntervalError)?;
+                if end_closed {
+                    Bound::Included(date)
+                } else {
+                    Bound::Excluded(date)
+                }
+            }
+            _ => Bound::Unbounded,
+        };
+
+        Ok(DateInterval(start_bound, end_bound))
     }
 }
 

--- a/src/schema/date_interval.rs
+++ b/src/schema/date_interval.rs
@@ -2,7 +2,7 @@ use std::{error::Error, fmt::Display, ops::Bound, str::FromStr};
 
 use async_graphql::{InputValueError, InputValueResult, Scalar, ScalarType, Value};
 use chrono::{Duration, NaiveDate};
-use postgres_types::{accepts, FromSql};
+use postgres_types::{accepts, FromSql, ToSql};
 
 #[derive(Debug, PartialEq)]
 pub struct DateInterval(pub Bound<NaiveDate>, pub Bound<NaiveDate>);
@@ -85,6 +85,33 @@ impl<'a> FromSql<'a> for DateInterval {
     accepts!(DATE_RANGE, TEXT);
 }
 
+impl ToSql for DateInterval {
+    fn to_sql(&self, _: &postgres_types::Type, out: &mut bytes::BytesMut) -> Result<postgres_types::IsNull, Box<dyn Error + Sync + Send>>
+    where
+        Self: Sized {
+        let encoded = self.to_pg_range_text();
+        out.extend_from_slice(encoded.as_bytes());
+        Ok(postgres_types::IsNull::No)
+    }
+
+    accepts!(DATE_RANGE);
+
+    fn to_sql_checked(
+        &self,
+        ty: &postgres_types::Type,
+        out: &mut bytes::BytesMut,
+    ) -> Result<postgres_types::IsNull, Box<dyn Error + Sync + Send>> {
+        if !<Self as ToSql>::accepts(ty) {
+            return Err("Unsupported PostgreSQL type".into());
+        }
+        self.to_sql(ty, out)
+    }
+
+    fn encode_format(&self, _ty: &postgres_types::Type) -> postgres_types::Format {
+        postgres_types::Format::Text
+    }
+}
+
 impl DateInterval {
     fn from_pg_range_text(s: &str) -> std::result::Result<Self, ParseDateIntervalError> {
         let trimmed = s.trim();
@@ -126,6 +153,22 @@ impl DateInterval {
         };
 
         Ok(DateInterval(start_bound, end_bound))
+    }
+
+    fn to_pg_range_text(&self) -> String {
+        let start_bound = match &self.0 {
+            Bound::Included(date) => format!("[{}", date.format("%Y-%m-%d")),
+            Bound::Excluded(date) => format!("({}", date.format("%Y-%m-%d")),
+            Bound::Unbounded => "(".to_string(),
+        };
+
+        let end_bound = match &self.1 {
+            Bound::Included(date) => format!(",{:}]", date.format("%Y-%m-%d")),
+            Bound::Excluded(date) => format!(",{:})", date.format("%Y-%m-%d")),
+            Bound::Unbounded => ",)".to_string(),
+        };
+
+        format!("{}{}", start_bound, end_bound)
     }
 }
 

--- a/src/schema/grade.rs
+++ b/src/schema/grade.rs
@@ -1,0 +1,58 @@
+use std::str::FromStr;
+
+use async_graphql::{OneofObject, SimpleObject, Union};
+
+use super::{
+    fontainebleau_grade::FontainebleauGrade, vermin_grade::VerminGrade,
+    yosemite_decimal_grade::YosemiteDecimalGrade,
+};
+
+#[derive(SimpleObject)]
+pub struct Fontainebleau {
+    pub value: FontainebleauGrade,
+}
+
+#[derive(SimpleObject)]
+pub struct YosemiteDecimal {
+    pub value: YosemiteDecimalGrade,
+}
+
+#[derive(SimpleObject)]
+pub struct Vermin {
+    pub value: VerminGrade,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ParseClimbGradeError;
+
+#[derive(Union)]
+pub enum Grade {
+    Vermin(Vermin),
+    Fontainebleau(Fontainebleau),
+    YosemiteDecimal(YosemiteDecimal),
+}
+
+impl FromStr for Grade {
+    type Err = ParseClimbGradeError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        VerminGrade::from_str(s)
+            .map(|v| Grade::Vermin(Vermin { value: v }))
+            .or_else(|_| {
+                FontainebleauGrade::from_str(s)
+                    .map(|f| Grade::Fontainebleau(Fontainebleau { value: f }))
+            })
+            .or_else(|_| {
+                YosemiteDecimalGrade::from_str(s)
+                    .map(|y| Grade::YosemiteDecimal(YosemiteDecimal { value: y }))
+            })
+            .map_err(|_| ParseClimbGradeError)
+    }
+}
+
+#[derive(Debug, OneofObject)]
+pub enum GradeInput {
+    Vermin(VerminGrade),
+    Fontainebleau(FontainebleauGrade),
+    YosemiteDecimal(YosemiteDecimalGrade),
+}

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -4,29 +4,21 @@ use async_graphql::{Context, Object, OneofObject, Result, SimpleObject, Union, I
 
 use area::Area;
 use climb::Climb;
-use fontainebleau_grade::FontainebleauGrade;
 use formation::{Coordinate, Formation};
+use grade::GradeInput;
 use postgres_types::ToSql;
-use vermin_grade::VerminGrade;
-use yosemite_decimal_grade::YosemiteDecimalGrade;
 
 use crate::AppData;
 
 pub mod area;
 pub mod climb;
 pub mod formation;
+pub mod grade;
 pub mod fontainebleau_grade;
 pub mod vermin_grade;
 pub mod yosemite_decimal_grade;
 
 pub struct QueryRoot;
-
-#[derive(Debug, OneofObject)]
-enum GradeInput {
-    Vermin(VerminGrade),
-    Fontainebleau(FontainebleauGrade),
-    YosemiteDecimal(YosemiteDecimalGrade),
-}
 
 impl Display for GradeInput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -195,6 +195,71 @@ impl Climber {
     }
 }
 
+struct Ascent(pub i32);
+
+#[Object]
+impl Ascent {
+    async fn id(&self) -> ID {
+        self.0.into()
+    }
+
+    async fn climb<'a>(
+        &self,
+        ctx: &Context<'a>,
+    ) -> Result<Climb> {
+        let data = ctx.data::<AppData>()?;
+        let client = match &data.pg_pool {
+            Some(pool) => pool.get().await?,
+            None => {
+                return Err("Database connection is not available".into());
+            }
+        };
+
+        let result = client
+            .query_one(
+                "
+                SELECT climb_id
+                FROM ascents
+                WHERE id = $1
+                ",
+                &[&self.0],
+            )
+            .await?;
+
+        let climb_id: i32 = result.try_get(0)?;
+
+        Ok(Climb(climb_id))
+    }
+
+    async fn climber<'a>(
+        &self,
+        ctx: &Context<'a>,
+    ) -> Result<Climber> {
+        let data = ctx.data::<AppData>()?;
+        let client = match &data.pg_pool {
+            Some(pool) => pool.get().await?,
+            None => {
+                return Err("Database connection is not available".into());
+            }
+        };
+
+        let result = client
+            .query_one(
+                "
+                SELECT climber_id
+                FROM ascents
+                WHERE id = $1
+                ",
+                &[&self.0],
+            )
+            .await?;
+
+        let climber_id: i32 = result.try_get(0)?;
+
+        Ok(Climber(climber_id))
+    }
+}
+
 #[Object]
 impl QueryRoot {
     async fn areas<'a>(
@@ -291,6 +356,52 @@ impl QueryRoot {
             .await?;
 
         Ok(Area(id))
+    }
+
+    async fn ascents<'a>(
+        &self,
+        ctx: &Context<'a>,
+    ) -> Result<Vec<Ascent>> {
+        let data = ctx.data::<AppData>()?;
+        let client = match &data.pg_pool {
+            Some(pool) => pool.get().await?,
+            None => {
+                return Err("Database connection is not available".into());
+            }
+        };
+
+        let result = client
+            .query("SELECT ascents.id FROM ascents", &[])
+            .await?;
+
+        let ascents = result
+            .into_iter()
+            .map(|row| row.try_get(0).map(Ascent))
+            .collect::<Result<Vec<Ascent>, _>>()?;
+
+        Ok(ascents)
+    }
+
+    async fn ascent<'a>(
+        &self,
+        ctx: &Context<'a>,
+        #[graphql(desc = "Ascent id")] id: ID,
+    ) -> Result<Ascent> {
+        let id: i32 = id.0.parse().map_err(|_| "Invalid ID format")?;
+        let data = ctx.data::<AppData>()?;
+        let client = match &data.pg_pool {
+            Some(pool) => pool.get().await?,
+            None => {
+                return Err("Database connection is not available".into());
+            }
+        };
+
+        // Just check for existence
+        client
+            .query_one("SELECT 1 FROM ascents WHERE id = $1", &[&id])
+            .await?;
+
+        Ok(Ascent(id))
     }
 
     async fn climbs<'a>(

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -1216,6 +1216,34 @@ impl MutationRoot {
         Ok(Climb(id))
     }
 
+    async fn add_ascent_grade<'a>(
+        &self,
+        ctx: &Context<'a>,
+        #[graphql(desc = "Ascent ID")] id: ID,
+        #[graphql(desc = "Grade")] grade: GradeInput,
+    ) -> Result<Ascent> {
+        let id: i32 = id.0.parse().map_err(|_| "Invalid ID format")?;
+        let data = ctx.data::<AppData>()?;
+        let client = match &data.pg_pool {
+            Some(pool) => pool.get().await?,
+            None => {
+                return Err("Database connection is not available".into());
+            }
+        };
+
+        client
+            .execute(
+                "
+                INSERT INTO ascent_grades (ascent_id, grade)
+                VALUES ($1, $2) ON CONFLICT DO NOTHING
+                ",
+                &[&id, &(grade)],
+            )
+            .await?;
+
+        Ok(Ascent(id))
+    }
+
     async fn add_climb_grade<'a>(
         &self,
         ctx: &Context<'a>,
@@ -1271,6 +1299,34 @@ impl MutationRoot {
             .get::<_, i32>(0);
 
         Ok(Climber(id))
+    }
+
+    async fn remove_ascent_grade<'a>(
+        &self,
+        ctx: &Context<'a>,
+        #[graphql(desc = "Ascent ID")] id: ID,
+        #[graphql(desc = "Grade")] grade: GradeInput,
+    ) -> Result<Ascent> {
+        let id: i32 = id.0.parse().map_err(|_| "Invalid ID format")?;
+        let data = ctx.data::<AppData>()?;
+        let client = match &data.pg_pool {
+            Some(pool) => pool.get().await?,
+            None => {
+                return Err("Database connection is not available".into());
+            }
+        };
+
+        client
+            .execute(
+                "
+                DELETE FROM ascent_grades
+                WHERE ascent_id = $1 AND grade = $2
+                ",
+                &[&id, &(grade)],
+            )
+            .await?;
+
+        Ok(Ascent(id))
     }
 
     async fn remove_climb_grade<'a>(

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -5,7 +5,7 @@ use async_graphql::{Context, Object, OneofObject, Result, SimpleObject, Union, I
 use area::Area;
 use climb::Climb;
 use formation::{Coordinate, Formation};
-use grade::GradeInput;
+use grade::{Grade, GradeInput};
 use postgres_types::ToSql;
 
 use crate::AppData;
@@ -249,6 +249,43 @@ impl Ascent {
         let climber_id: i32 = result.try_get(0)?;
 
         Ok(Climber(climber_id))
+    }
+
+    async fn grades<'a>(
+        &self,
+        ctx: &Context<'a>,
+    ) -> Result<Vec<Grade>> {
+        let data = ctx.data::<AppData>()?;
+        let client = match &data.pg_pool {
+            Some(pool) => pool.get().await?,
+            None => {
+                return Err("Database connection is not available".into());
+            }
+        };
+
+        let value: Vec<Grade> = client
+            // TODO since grade doesn't implement binary functions, we must request the text
+            // format, when grade _does_ implement these, the ::TEXT is not needed
+            .query(
+                "
+                SELECT grade::TEXT
+                FROM ascent_grades
+                WHERE ascent_id = $1
+                ",
+                &[&self.0],
+            )
+            .await?
+            .into_iter()
+            .filter_map(|row| {
+                let grade_str: String = row.get(0);
+                match grade_str.parse::<Grade>() {
+                    Ok(grade) => Some(grade),
+                    Err(_) => None,
+                }
+            })
+            .collect();
+
+        Ok(value)
     }
 }
 

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -12,6 +12,7 @@ use crate::AppData;
 
 pub mod area;
 pub mod climb;
+pub mod date_interval;
 pub mod formation;
 pub mod grade;
 pub mod fontainebleau_grade;

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -4,6 +4,7 @@ use async_graphql::{Context, Object, OneofObject, Result, SimpleObject, Union, I
 
 use area::Area;
 use climb::Climb;
+use date_interval::DateInterval;
 use formation::{Coordinate, Formation};
 use grade::{Grade, GradeInput};
 use postgres_types::ToSql;
@@ -250,6 +251,35 @@ impl Ascent {
         let climber_id: i32 = result.try_get(0)?;
 
         Ok(Climber(climber_id))
+    }
+
+    async fn date_window<'a>(
+        &self,
+        ctx: &Context<'a>,
+    ) -> Result<Option<DateInterval>> {
+        let data = ctx.data::<AppData>()?;
+        let client = match &data.pg_pool {
+            Some(pool) => pool.get().await?,
+            None => {
+                return Err("Database connection is not available".into());
+            }
+        };
+
+        let result = client
+            // TODO sfackler/rust-postgres-range#18
+            .query_one(
+                "
+                SELECT date_window::TEXT
+                FROM ascents
+                WHERE id = $1
+                ",
+                &[&self.0],
+            )
+            .await?;
+
+        let value: Option<DateInterval> = result.try_get(0)?;
+
+        Ok(value)
     }
 
     async fn grades<'a>(

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -805,6 +805,37 @@ impl MutationRoot {
         Ok(Area(area_id))
     }
 
+    async fn add_ascent<'a>(
+        &self,
+        ctx: &Context<'a>,
+        #[graphql(desc = "Climb ID")] climb_id: ID,
+        #[graphql(desc = "Climber ID")] climber_id: ID,
+    ) -> Result<Ascent> {
+        let climb_id: i32 = climb_id.0.parse().map_err(|_| "Invalid ID format")?;
+        let climber_id: i32 = climber_id.0.parse().map_err(|_| "Invalid ID format")?;
+        let data = ctx.data::<AppData>()?;
+        let client = match &data.pg_pool {
+            Some(pool) => pool.get().await?,
+            None => {
+                return Err("Database connection is not available".into());
+            }
+        };
+
+        let ascent_id = client
+            .query_one(
+                "
+                INSERT INTO ascents (climb_id, climber_id)
+                VALUES ($1, $2)
+                RETURNING id
+                ",
+                &[&climb_id, &climber_id],
+            )
+            .await?
+            .get::<_, i32>(0);
+
+        Ok(Ascent(ascent_id))
+    }
+
     async fn rename_area<'a>(
         &self,
         ctx: &Context<'a>,
@@ -946,6 +977,27 @@ impl MutationRoot {
             .await?;
 
         Ok(Area(id))
+    }
+
+    async fn remove_ascent<'a>(
+        &self,
+        ctx: &Context<'a>,
+        #[graphql(desc = "Ascent id")] id: ID,
+    ) -> Result<Ascent> {
+        let id: i32 = id.0.parse().map_err(|_| "Invalid ID format")?;
+        let data = ctx.data::<AppData>()?;
+        let client = match &data.pg_pool {
+            Some(pool) => pool.get().await?,
+            None => {
+                return Err("Database connection is not available".into());
+            }
+        };
+
+        client
+            .execute("DELETE FROM ascents WHERE id = $1", &[&id])
+            .await?;
+
+        Ok(Ascent(id))
     }
 
     async fn add_climb<'a>(

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -896,6 +896,37 @@ impl MutationRoot {
         Ok(Ascent(ascent_id))
     }
 
+    async fn date_ascent<'a>(
+        &self,
+        ctx: &Context<'a>,
+        #[graphql(desc = "Ascent ID")] id: ID,
+        #[graphql(desc = "Area name")] date_interval: Option<DateInterval>,
+    ) -> Result<Ascent> {
+        let id: i32 = id.0.parse().map_err(|_| "Invalid ID format")?;
+        let data = ctx.data::<AppData>()?;
+        let client = match &data.pg_pool {
+            Some(pool) => pool.get().await?,
+            None => {
+                return Err("Database connection is not available".into());
+            }
+        };
+
+        let ascent_id = client
+            .query_one(
+                "
+                UPDATE ascents
+                SET date_window = $1
+                WHERE id = $2
+                RETURNING id
+                ",
+                &[&date_interval, &id],
+            )
+            .await?
+            .get::<_, i32>(0);
+
+        Ok(Ascent(ascent_id))
+    }
+
     async fn rename_area<'a>(
         &self,
         ctx: &Context<'a>,


### PR DESCRIPTION
This _does not_ add the date window support, yet. This is because there is not a great native rust-postgres way of getting PostgreSQLs DATERANGE type. Looks like there's sfackler/rust-postgres-range#18, but it hasn't been merged in a year and the general state of rust-postgres-range seems unmaintained.. perhaps @tkbrigham has a good point in sfackler/rust-postgres#601.. it'd be great if all the PostgreSQL features were supported in rust-postgres directly.